### PR TITLE
Fix remove known_hosts on destroy

### DIFF
--- a/nixopsvbox/backends/virtualbox.py
+++ b/nixopsvbox/backends/virtualbox.py
@@ -618,7 +618,7 @@ class VirtualBoxState(MachineState[VirtualBoxDefinition]):
 
         time.sleep(1)  # hack to work around "machine locked" errors
 
-        nixops.known_hosts.update(self.private_ipv4, None, self.public_host_key)
+        nixops.known_hosts.remove(self.private_ipv4, self.public_host_key)
 
         self._logged_exec(["VBoxManage", "unregistervm", "--delete", self.vm_id])
 


### PR DESCRIPTION
* Fixes failed vbox destroy due to nixops known_hosts api change as of https://github.com/nixos/nixops/pull/1233
* See upstream PR comment: https://github.com/NixOS/nixops/pull/1233#discussion_r396161195
* See related comment in nixops-aws commit: https://github.com/NixOS/nixops-aws/commit/395079c80bd5cf4d6c1c9c16be882b34a80d1bfe