### PR TITLE
make creating initial vbox disks work with nixops 35ac0208

### DIFF
--- a/nixopsvbox/backends/virtualbox.py
+++ b/nixopsvbox/backends/virtualbox.py
@@ -405,6 +405,7 @@ class VirtualBoxState(MachineState[VirtualBoxDefinition]):
                             checkConfigurationOptions=False,
                             attr='nodes."{0}".config.deployment.virtualbox.disks.{1}.baseImage'.format(self.name, disk_name),
                             pluginNixExprs=PluginManager.nixexprs(),
+                            build=True,
                         )
                     self._logged_exec(
                         [

--- a/nixopsvbox/backends/virtualbox.py
+++ b/nixopsvbox/backends/virtualbox.py
@@ -9,6 +9,12 @@ import nixops.known_hosts
 from typing import Sequence, Optional, Mapping
 from nixops.state import RecordId
 
+import nixops
+
+from nixops.plugins.manager import (
+    PluginManager,
+)
+
 
 SATA_PORTS = 8
 
@@ -388,28 +394,18 @@ class VirtualBoxState(MachineState[VirtualBoxDefinition]):
                 disk_path = "{0}/{1}.vdi".format(vm_dir, disk_name)
 
                 base_image = disk_def.baseImage
+
                 if base_image:
                     # Clone an existing disk image.
                     if base_image == "drv":
-                        # FIXME: move this to deployment.py.
-                        base_image = self._logged_exec(
-                            ["nix-build"]
-                            + self.depl._eval_flags(self.depl.nix_exprs)
-                            + [
-                                "--arg",
-                                "checkConfigurationOptions",
-                                "false",
-                                "-A",
-                                'nodes."{0}".config.deployment.virtualbox.disks.{1}.baseImage'.format(
-                                    self.name, disk_name
-                                ),
-                                "-o",
-                                "{0}/vbox-image-{1}".format(
-                                    self.depl.tempdir, self.name
-                                ),
-                            ],
-                            capture_stdout=True,
-                        ).rstrip()
+                        base_image = nixops.evaluation.eval(
+                            networkExpr=self.depl.network_expr,
+                            uuid=self.depl.uuid,
+                            deploymentName=self.depl.name or "",
+                            checkConfigurationOptions=False,
+                            attr='nodes."{0}".config.deployment.virtualbox.disks.{1}.baseImage'.format(self.name, disk_name),
+                            pluginNixExprs=PluginManager.nixexprs(),
+                        )
                     self._logged_exec(
                         [
                             "VBoxManage",


### PR DESCRIPTION
`_eval_flags` and `nix_exprs` are undefined in nixops 35ac0208, which causes an error when deploying with `targetEnv="virtualbox"` -  one can use `nixops.evaluation.eval` instead  to make it work.

full trace:

```
git............> creating VirtualBox VM...
git............> Virtual machine 'nixops-c9e5f533-02c9-11ec-8d2a-f01faf415644-git' is created and registered.
git............> UUID: 657a996c-25fd-4d9b-8403-c6b9b9e8559f
git............> Settings file: '/home/kpg/VirtualBox VMs/nixops-c9e5f533-02c9-11ec-8d2a-f01faf415644-git/nixops-c9e5f533-02c9-11ec-8d2a-f01faf415644-git.vbox'
git............> creating disk ‘disk1’...
Traceback (most recent call last):
  File "/nix/store/xj0midzl1ynx6s8w82x136xc96bg8qwl-python3.8-nixops-20210821/bin/.nixops-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/hd7zizr2v0fvi8sh733lkdvlb1b9gvsy-python3-3.8.9-env/lib/python3.8/site-packages/nixops/__main__.py", line 56, in main
    args.op(args)
  File "/nix/store/hd7zizr2v0fvi8sh733lkdvlb1b9gvsy-python3-3.8.9-env/lib/python3.8/site-packages/nixops/script_defs.py", line 688, in op_deploy
    depl.deploy(
  File "/nix/store/hd7zizr2v0fvi8sh733lkdvlb1b9gvsy-python3-3.8.9-env/lib/python3.8/site-packages/nixops/deployment.py", line 1352, in deploy
    self.run_with_notify("deploy", lambda: self._deploy(**kwargs))
  File "/nix/store/hd7zizr2v0fvi8sh733lkdvlb1b9gvsy-python3-3.8.9-env/lib/python3.8/site-packages/nixops/deployment.py", line 1341, in run_with_notify
    f()
  File "/nix/store/hd7zizr2v0fvi8sh733lkdvlb1b9gvsy-python3-3.8.9-env/lib/python3.8/site-packages/nixops/deployment.py", line 1352, in <lambda>
    self.run_with_notify("deploy", lambda: self._deploy(**kwargs))
  File "/nix/store/hd7zizr2v0fvi8sh733lkdvlb1b9gvsy-python3-3.8.9-env/lib/python3.8/site-packages/nixops/deployment.py", line 1255, in _deploy
    nixops.parallel.run_tasks(
  File "/nix/store/hd7zizr2v0fvi8sh733lkdvlb1b9gvsy-python3-3.8.9-env/lib/python3.8/site-packages/nixops/parallel.py", line 106, in run_tasks
    raise list(exceptions.values())[0]
  File "/nix/store/hd7zizr2v0fvi8sh733lkdvlb1b9gvsy-python3-3.8.9-env/lib/python3.8/site-packages/nixops/parallel.py", line 70, in thread_fun
    work_result = (worker_fun(t), None, t.name)
  File "/nix/store/hd7zizr2v0fvi8sh733lkdvlb1b9gvsy-python3-3.8.9-env/lib/python3.8/site-packages/nixops/deployment.py", line 1207, in worker
    r.create(
  File "/nix/store/hd7zizr2v0fvi8sh733lkdvlb1b9gvsy-python3-3.8.9-env/lib/python3.8/site-packages/nixopsvbox/backends/virtualbox.py", line 397, in create
    + self.depl._eval_flags(self.depl.nix_exprs)
AttributeError: 'Deployment' object has no attribute '_eval_flags'

```