### PR TITLE
fix: properly remove destroyed vm known host

### DIFF
--- a/nixopsvbox/backends/virtualbox.py
+++ b/nixopsvbox/backends/virtualbox.py
@@ -618,7 +618,7 @@ class VirtualBoxState(MachineState[VirtualBoxDefinition]):
 
         time.sleep(1)  # hack to work around "machine locked" errors
 
-        nixops.known_hosts.update(self.private_ipv4, None, self.public_host_key)
+        nixops.known_hosts.remove(self.private_ipv4, self.public_host_key)
 
         self._logged_exec(["VBoxManage", "unregistervm", "--delete", self.vm_id])
 


### PR DESCRIPTION
Calling `update` is meant to change the IP, not just to remove it.

You can see that because [it *always* adds the new IP][1].

Here we're inside `destroy()`, so there's no use for trying to add an IP of a machine that no longer exists.

This was producing the following exception:

```
Traceback (most recent call last):
  File "/nix/store/7w0556wlj4sl1r8wy0alq6dilyg0dp7n-python3-3.8.9-env/lib/python3.8/site-packages/nixops/parallel.py", line 70, in thread_fun
    work_result = (worker_fun(t), None, t.name)
  File "/nix/store/7w0556wlj4sl1r8wy0alq6dilyg0dp7n-python3-3.8.9-env/lib/python3.8/site-packages/nixops/deployment.py", line 1462, in worker
    if m.destroy(wipe=wipe):
  File "/nix/store/7w0556wlj4sl1r8wy0alq6dilyg0dp7n-python3-3.8.9-env/lib/python3.8/site-packages/nixopsvbox/backends/virtualbox.py", line 617, in destroy
    nixops.known_hosts.update(self.private_ipv4, None, self.public_host_key)
  File "/nix/store/7w0556wlj4sl1r8wy0alq6dilyg0dp7n-python3-3.8.9-env/lib/python3.8/site-packages/nixops/known_hosts.py", line 71, in update
    add(new_address, public_host_key)
  File "/nix/store/7w0556wlj4sl1r8wy0alq6dilyg0dp7n-python3-3.8.9-env/lib/python3.8/site-packages/nixops/known_hosts.py", line 64, in add
    _rewrite(ip_address, True, public_host_key)
  File "/nix/store/7w0556wlj4sl1r8wy0alq6dilyg0dp7n-python3-3.8.9-env/lib/python3.8/site-packages/nixops/known_hosts.py", line 48, in _rewrite
    new.append(ip_address + " " + public_host_key)
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

@moduon MT-904

[1]: https://github.com/NixOS/nixops/blob/fc78a6448a232cb73b33c0912dad4b2c49766ef4/nixops/known_hosts.py#L71