### PR TITLE
be robust to malformed `showvminfo` output

### DIFF
--- a/nixopsvbox/backends/virtualbox.py
+++ b/nixopsvbox/backends/virtualbox.py
@@ -146,6 +146,8 @@ class VirtualBoxState(MachineState[VirtualBoxDefinition]):
             )
         vminfo = {}
         for line in lines:
+            if not "=" in line:
+                continue
             (k, v) = line.split("=", 1)
             vminfo[k] = v if not len(v) or v[0] != '"' else v[1:-1]
         return vminfo


### PR DESCRIPTION
recent versions of mac os x virtualbos seem to include a sort of section header for recording screen properties, which causes vm creation to fatal because it's not in the expected k=v format. let's just skip over these lines.

fixes #31